### PR TITLE
pass linkage test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,13 +17,13 @@ DEFAULT          := android
 DEFAULT          := test
 ACTIVE_PACKAGE   := basic-android-integration
 
-#NOCAPTURE := --nocapture
+NOCAPTURE := --nocapture
 
 #----------------------------------------------[here are our rules]
 
 default: $(DEFAULT)
 
-ANDROID_NDK_HOME := /usr/local/share/android-ndk
+ANDROID_NDK_HOME := /home/loko/Android/Sdk/ndk/27/
 
 android:
 	ANDROID_NDK_HOME=$(ANDROID_NDK_HOME) \
@@ -35,10 +35,12 @@ test:
 	ANDROID_NDK_HOME=$(ANDROID_NDK_HOME) \
 	RUSTFLAGS=$(RUSTFLAGS) \
 	RUST_LOG=trace \
-	$(CARGO) $(NDK) -t armeabi-v7a build --package $(ACTIVE_PACKAGE) --tests
+	 $(CARGO) $(NDK) -t armeabi-v7a build --package $(ACTIVE_PACKAGE) --tests
+    ## $(CARGO) $(NDK) -t arm64-v8a build --package $(ACTIVE_PACKAGE) --tests
 
 	@echo "Locating test binary"
 	BINARY=$$(find target/armv7-linux-androideabi/debug/deps -type f -name "$(subst -,_,$(ACTIVE_PACKAGE))-*" ! -name "*.d" ! -name "*.rlib" | head -n 1); \
+	##BINARY=$$(find target/aarch64-linux-android/debug/deps -type f -name "$(subst -,_,$(ACTIVE_PACKAGE))-*" ! -name "*.d" ! -name "*.rlib" | head -n 1); \
 	if [ -z "$$BINARY" ]; then \
 		echo "Error: Test binary not found."; \
 		echo "Searched for pattern: '$(subst -,_,$(ACTIVE_PACKAGE))-*' in target/armv7-linux-androideabi/debug/deps/"; \

--- a/basic-android-integration/Cargo.toml
+++ b/basic-android-integration/Cargo.toml
@@ -10,6 +10,7 @@ description = "todo: write a description here"
 # categories = []
 
 [dependencies]
+ptr = "*"
 ndk                     = "*"
 ndk-sys                 = "*"
 jni                     = "*"

--- a/basic-android-integration/build.rs
+++ b/basic-android-integration/build.rs
@@ -31,11 +31,14 @@ fn android() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("cargo:rustc-link-lib=c++_shared");
     debug!("Configured cargo to link library 'c++_shared'");
+        
+     println!("cargo:rustc-link-lib=amidi");
+println!("cargo:rustc-link-search=/home/loko/Android/Sdk/ndk/27/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/arm-linux-androideabi/30/");
 
     let output_path = env::var("CARGO_NDK_OUTPUT_PATH")
         .unwrap_or_else(|_| "./target/ndk-output".into());
     debug!(output_path, "Retrieved or defaulted CARGO_NDK_OUTPUT_PATH");
-
+//let target_triple= "aarch64-linux-android";
     let target_triple = "arm-linux-androideabi";
     warn!(target_triple, "Using hardcoded target triple");
 
@@ -44,7 +47,7 @@ fn android() -> Result<(), Box<dyn std::error::Error>> {
     debug!(ndk_home, "Retrieved ANDROID_NDK_HOME");
 
     let libcxx_shared_path = PathBuf::from(&ndk_home)
-        .join("toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/lib")
+        .join("toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib")
         .join(&target_triple)
         .join("libc++_shared.so");
 
@@ -55,7 +58,7 @@ fn android() -> Result<(), Box<dyn std::error::Error>> {
         return Err(format!("Could not find libc++_shared.so at {:?}", libcxx_shared_path).into());
     }
 
-    let target_output_path = PathBuf::from(output_path)
+    let mut target_output_path = PathBuf::from(output_path.clone())
         .join(&target_triple)
         .join("libc++_shared.so");
 
@@ -66,6 +69,34 @@ fn android() -> Result<(), Box<dyn std::error::Error>> {
 
     fs::copy(&libcxx_shared_path, &target_output_path)?;
     info!(from = ?libcxx_shared_path, to = ?target_output_path, "Copied libc++_shared.so successfully");
+
+//------
+ let libamidi_path = PathBuf::from(&ndk_home)
+        .join("toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib")
+        .join("arm-linux-androideabi")
+        .join("30")
+        .join("libamidi.so");
+
+    debug!(?libamidi_path, "Constructed libamidi.so source path");
+
+    if !libamidi_path.exists() {
+        error!(?libamidi_path, "libamidi.so not found");
+        return Err(format!("Could not find libamidi.so at {:?}", libamidi_path).into());
+    }
+
+     target_output_path = PathBuf::from(output_path)
+        .join(&target_triple)
+        .join("libamidi.so");
+
+    debug!(?target_output_path, "Constructed libamidi.so target path");
+
+    fs::create_dir_all(target_output_path.parent().unwrap())?;
+    debug!(parent = ?target_output_path.parent(), "Ensured parent directory exists");
+
+    fs::copy(&libamidi_path, &target_output_path)?;
+    info!(from = ?libamidi_path, to = ?target_output_path, "Copied libamidi.so successfully");
+//_--
+
 
     Ok(())
 }

--- a/basic-android-integration/src/basic_android_integration.rs
+++ b/basic-android-integration/src/basic_android_integration.rs
@@ -1,5 +1,6 @@
 crate::ix!();
-
+use std::io::{self, Write}; // Import io::Write for flush
+use std::ptr; // Import the ptr module
 fn example_function() {
 
     let env:                *mut jni::sys::JNIEnv          = todo!();
@@ -26,22 +27,110 @@ fn example_function() {
 }
 
 fn load_amidi() -> Result<(), Box<dyn std::error::Error>> {
+    
     unsafe {
-        let lib = Library::new("libamidi.so")?;
-        let amidi_get_version: Symbol<unsafe extern "C" fn() -> u32> =
-            lib.get(b"AMidi_getVersion")?;
-        let version = amidi_get_version();
-        println!("AMidi version: {}", version);
+            // Attempt to load by absolute path first for diagnostics
+       // let lib_path = "/system/lib/libamidi.so"; // Correct for 32-bit target
+        //println!("[RUST_TEST_DEBUG] Attempting to load by absolute path: {}", lib_path);
+        //io::stdout().flush().unwrap_or_default();
+
+        let lib = match Library::new("libamidi.so"){
+        //let lib = match Library::new(lib_path) {
+            Ok(l) => {
+                println!("[RUST_TEST_DEBUG] Successfully loaded");
+               // println!("[RUST_TEST_DEBUG] Successfully loaded from absolute path: {}", lib_path);
+                //io::stdout().flush().unwrap_or_default();
+                l
+            }
+            Err(e) => {
+                println!("[RUST_TEST_DEBUG] Failed to load Trying 'libamidi.so' by name");
+                //io::stdout().flush().unwrap_or_default();
+                Library::new("libamidi.so")?
+            }
+        };
+
+        // Try to get AMidiDevice_fromJava as an additional test
+        match lib.get::<unsafe extern "C" fn(*mut jni::sys::JNIEnv, jni::sys::jobject, *mut *mut ndk_sys::AMidiDevice) -> ndk_sys::media_status_t>(b"AMidiDevice_fromJava\0") {
+           Ok(_) => {
+                println!("[RUST_TEST_DEBUG] Successfully got symbol 'AMidiDevice_fromJava'");
+                //io::stdout().flush().unwrap_or_default();
+            }
+            Err(e) => {
+                println!("[RUST_TEST_DEBUG] Failed to get symbol 'AMidiDevice_fromJava': {:?}", e);
+                return Err(Box::new(e)); // Propagate this error to make the test fail
+            }
+        }
+
+       /*  // Try to get AMidi_getVersion
+        match lib.get::<unsafe extern "C" fn() -> u32>(b"AMidi_getVersion\0") {
+            Ok(amidi_get_version_fn) => {
+                let version = amidi_get_version_fn();
+                println!("[RUST_TEST_DEBUG] AMidi_getVersion() returned: {}", version);
+            }
+            Err(e) => {
+                println!("[RUST_TEST_DEBUG] Failed to get symbol 'AMidi_getVersion': {:?}", e);
+                // Re-throw the error to make the test fail as before if this is the problematic symbol
+                io::stdout().flush().unwrap_or_default();
+                return Err(Box::new(e)); 
+            }
+        } */
+ 
+   
     }
     Ok(())
 }
+
 
 
 #[cfg(test)]
 mod test_libloading {
     use super::*;
 
-    #[traced_test] fn test_load_amidi() {
+   // #[traced_test] 
+   #[test]
+   fn test_load_amidi() {
+        println!("[RUST_TEST_DEBUG] LD_LIBRARY_PATH: {:?}", std::env::var("LD_LIBRARY_PATH"));
+       // io::stdout().flush().unwrap_or_default();
+        println!("[RUST_TEST_DEBUG] RUST_BACKTRACE: {:?}", std::env::var("RUST_BACKTRACE"));
+       // io::stdout().flush().unwrap_or_default();
         load_amidi().expect("expected to load amidi object");
+       println!("test TEST TEST last LINe");
+    }
+}
+
+#[cfg(test)]
+mod test_linking {
+    use super::*; // To get ndk_sys, ptr, etc.
+
+    #[test]
+    fn test_amidi_device_from_java_linkage() {
+        println!("[RUST_TEST_DEBUG] Testing AMidiDevice_fromJava linkage (expects libamidi.so to be auto-linked by NDK).");
+
+        // These are dummy values solely for testing the linkage.
+        // A real, functional call would require valid JNIEnv and jobject instances
+        // obtained from the Java side of an Android application.
+        let dummy_env: *mut jni::sys::JNIEnv = ptr::null_mut();
+        let dummy_midi_device_obj: jni::sys::jobject = ptr::null_mut(); 
+        let mut out_device_ptr: *mut ndk_sys::AMidiDevice = ptr::null_mut();
+
+        // The primary goal here is to see if this line compiles and links,
+        // and if libamidi.so is loaded by the OS (check LD_DEBUG=libs output from Makefile).
+        // The function call itself will likely fail (return an error status) or could
+        // potentially crash if the NDK function doesn't handle null pointers gracefully,
+        // but that's acceptable for a pure linkage test.
+        println!("[RUST_TEST_DEBUG] Calling ndk_sys::AMidiDevice_fromJava with dummy pointers...");
+        let status = unsafe {
+            ndk_sys::AMidiDevice_fromJava(
+                dummy_env,
+                dummy_midi_device_obj,
+                &mut out_device_ptr, // Pass a pointer to our out_device_ptr
+            )
+        };
+
+        println!("[RUST_TEST_DEBUG] ndk_sys::AMidiDevice_fromJava call completed with status: {:?}", status);
+        println!("[RUST_TEST_DEBUG] Value of out_device_ptr after call: {:?}", out_device_ptr);
+
+        // If we reached here without a linker error during build or an OS error about libamidi.so not found at runtime, the linkage is working.
+        // The LD_DEBUG=libs output (captured in test_output.txt by your Makefile) will be key to confirm libamidi.so was loaded.
     }
 }


### PR DESCRIPTION
I've managed to do the linking via build.rs.

Some of the code might be redundant or simply wrong, but this code compiles on my machine and passes both tests.

I've linked to the library in build.rs with: 

`   println!("cargo:rustc-link-lib=amidi");
   println!("cargo:rustc-link-search=/home/loko/Android/Sdk/ndk/27/toolchains/llvm/prebuilt/linux-  x86_64/sysroot/usr/lib/arm-linux-androideabi/30/");
`

So the paths are still hardcoded for now.
While trying to get the linking right I also added:

`//------
 let libamidi_path = PathBuf::from(&ndk_home)
        .join("toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib")
        .join("arm-linux-androideabi")
        .join("30")
        .join("libamidi.so");

    debug!(?libamidi_path, "Constructed libamidi.so source path");

    if !libamidi_path.exists() {
        error!(?libamidi_path, "libamidi.so not found");
        return Err(format!("Could not find libamidi.so at {:?}", libamidi_path).into());
    }

     target_output_path = PathBuf::from(output_path)
        .join(&target_triple)
        .join("libamidi.so");

    debug!(?target_output_path, "Constructed libamidi.so target path");

    fs::create_dir_all(target_output_path.parent().unwrap())?;
    debug!(parent = ?target_output_path.parent(), "Ensured parent directory exists");

    fs::copy(&libamidi_path, &target_output_path)?;
    info!(from = ?libamidi_path, to = ?target_output_path, "Copied libamidi.so successfully");
//_--`

I don't know if this is really needed, it was just for trying things out. 
But code compiles, runs and passes the test.

Maybe I should add an OS-check so we do not have do edit the paths manually, if we want to try  to compile.